### PR TITLE
Added WarpZone redirect to fix issue #4

### DIFF
--- a/data.json
+++ b/data.json
@@ -21,6 +21,11 @@
         "showInNav": true
       },
       {
+        "name": "Warpzone",
+        "file": "warpzone.html",
+        "showInNav": true
+      },
+      {
         "name": "Resources",
         "file": "resources.html",
         "showInNav": true

--- a/site.json
+++ b/site.json
@@ -20,6 +20,11 @@
       "showInNav": true
     },
     {
+      "name": "Warpzone",
+      "file": "warpzone.html",
+      "showInNav": true
+    },
+    {
       "name": "Resources",
       "file": "resources.html",
       "showInNav": true

--- a/src/pages/warpzone.hbs
+++ b/src/pages/warpzone.hbs
@@ -1,0 +1,1 @@
+<meta http-equiv="Refresh" content="0; url='http://warpzonelouisville.com/'" />

--- a/src/pages/warpzone/index.html
+++ b/src/pages/warpzone/index.html
@@ -1,0 +1,1 @@
+<meta http-equiv="Refresh" content="0; url='http://warpzonelouisville.com/'" />

--- a/static-site-generator.js
+++ b/static-site-generator.js
@@ -13,9 +13,8 @@ makeDirIfNotExist(path.join(dest, "css"));
 copydir.sync(path.join(src, "css"), path.join(dest, "css"));
 makeDirIfNotExist(path.join(dest, "img"));
 copydir.sync(path.join(src, "img"), path.join(dest, "img"));
-makeDirIfNotExist(path.join(dest, "js"));
-copydir.sync(path.join(src, "js"), path.join(dest, "js"));
-
+makeDirIfNotExist(path.join(dest, "warpzone"));
+copydir.sync(path.join(src, "pages/warpzone"), path.join(dest, "warpzone"));
 
 
 let data = {};


### PR DESCRIPTION
Added "warpzone" redirects to `/warpzone` and `/warpzone/`, the latter of which is the actual URL being used by the city of louisville page as raised in the issue.  Per conversation with @AlexBezuska, kept the Warpzone link in the nav bar in the current location.

Note that the `/warpzone/` leverages a standalone folder copy, and may feel slightly hacky, but it works and didn't seem worth adding subfolder processing for a single redirect.

This should close issue #4.